### PR TITLE
Fix missing fetch on IE11, fix missing localStorage on Safari

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,10 +5,7 @@
                 ["env",   {
                     "useBuiltIns": true
                 }],
-                "stage-2",
-                ["es2015", {
-                    "modules": false
-                }]
+                "stage-2"
             ],
             "plugins": [
                 "transform-object-assign"
@@ -20,10 +17,7 @@
                     "useBuiltIns": true
                 }],
                 "stage-2",
-                "react",
-                ["es2015", {
-                    "modules": false
-                }]
+                "react"
             ],
             "plugins": [
                 "transform-runtime",
@@ -32,12 +26,9 @@
         },
         "test": {
             "presets": [
-                ["env"],
+                "env",
                 "stage-2",
-                "react",
-                ["es2015", {
-                    "modules": false
-                }]
+                "react"
             ],
             "plugins": [
                 "transform-runtime",

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -54,7 +54,7 @@ module.exports = function(options) {
         entry = {
             frame: './src/frame/js/index'
         };
-    } else if (buildType === 'dev') {
+    } else if (buildType === 'dev' || buildType === 'test') {
         entry = {
             [vendorId]: './src/host/js/index',
             frame: './src/frame/js/index'

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -52,12 +52,12 @@ module.exports = function(options) {
         };
     } else if (buildType === 'frame') {
         entry = {
-            frame: ['babel-polyfill', './src/frame/js/index']
+            frame: './src/frame/js/index'
         };
     } else if (buildType === 'dev') {
         entry = {
             [vendorId]: './src/host/js/index',
-            frame: ['babel-polyfill', './src/frame/js/index']
+            frame: './src/frame/js/index'
         };
     } else {
         throw new Error('Unknown build type');

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -54,7 +54,7 @@ module.exports = function(options) {
         entry = {
             frame: ['babel-polyfill', './src/frame/js/index']
         };
-    } else if (buildType === 'dev' || buildType === 'test') {
+    } else if (buildType === 'dev') {
         entry = {
             [vendorId]: './src/host/js/index',
             frame: ['babel-polyfill', './src/frame/js/index']

--- a/make-webpack-config.js
+++ b/make-webpack-config.js
@@ -52,12 +52,12 @@ module.exports = function(options) {
         };
     } else if (buildType === 'frame') {
         entry = {
-            frame: './src/frame/js/index'
+            frame: ['babel-polyfill', './src/frame/js/index']
         };
     } else if (buildType === 'dev' || buildType === 'test') {
         entry = {
             [vendorId]: './src/host/js/index',
-            frame: './src/frame/js/index'
+            frame: ['babel-polyfill', './src/frame/js/index']
         };
     } else {
         throw new Error('Unknown build type');
@@ -175,7 +175,7 @@ module.exports = function(options) {
         path: options.outputPath || path.join(__dirname, buildType === 'npm' ? 'lib' : 'dist'),
         publicPath,
         filename: baseFilename + fileExtension,
-        chunkFilename: buildType === 'dev' ? '[id].js' : '[chunkhash].js',
+        chunkFilename: '[chunkhash].js',
         libraryTarget: buildType === 'npm' ? 'commonjs2' : 'var',
         pathinfo: options.debug
     };

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-assign": "6.22.0",
     "babel-plugin-transform-runtime": "6.23.0",
-    "babel-polyfill": "6.23.0",
+    "babel-polyfill": "6.26.0",
     "babel-preset-env": "1.5.1",
     "babel-preset-es2015": "6.24.1",
     "babel-preset-react": "6.24.1",
@@ -117,7 +117,7 @@
     "optimize-css-assets-webpack-plugin": "2.0.0",
     "phantomjs-prebuilt": "2.1.4",
     "prop-types": "15.5.10",
-    "raven-js": "3.15.0",
+    "raven-js": "3.17.0",
     "raw-loader": "0.5.1",
     "react": "15.5.4",
     "react-addons-css-transition-group": "15.5.2",
@@ -144,8 +144,9 @@
     "url-loader": "0.5.9",
     "urljoin": "0.1.5",
     "uuid": "2.0.1",
-    "webpack": "2.6.0",
+    "webpack": "3.6.0",
     "webpack-cli": "1.3.3",
-    "webpack-dev-middleware": "1.9.0"
+    "webpack-dev-middleware": "1.12.0",
+    "whatwg-fetch": "2.0.3"
   }
 }

--- a/release_notes/v4.0.1.md
+++ b/release_notes/v4.0.1.md
@@ -1,0 +1,3 @@
+# What's changed?
+- A polyfill for `fetch` has been added as it was previously included by `smooch-core` before v4.0.0.
+- A fix was made for when `localStorage` is not present in the global scope.

--- a/src/frame/js/actions/http.js
+++ b/src/frame/js/actions/http.js
@@ -93,7 +93,7 @@ export default function http(method, url, data, extraHeaders = {}, baseUrl) {
         }
 
         const fullUrl = urljoin(baseUrl || config.apiBaseUrl, url);
-        return fetch(fullUrl, fetchOptions)
+        return global.fetch(fullUrl, fetchOptions)
             .then(handleResponse);
     };
 }

--- a/src/frame/js/index.js
+++ b/src/frame/js/index.js
@@ -1,4 +1,6 @@
-import './utils/polyfills';
-import './utils/raven';
-import * as WebMessenger from './web-messenger';
-parent.window.__onWebMessengerFrameReady__(WebMessenger);
+require('./utils/raven');
+const {setUp} = require('./utils/polyfills');
+setUp().then(() => {
+    const WebMessenger = require('./web-messenger');
+    parent.window.__onWebMessengerFrameReady__(WebMessenger);
+});

--- a/src/frame/js/utils/client.js
+++ b/src/frame/js/utils/client.js
@@ -15,17 +15,16 @@ export function upgradeLegacyClientId(appId) {
 }
 
 export function getClientId(appId) {
-    const SK_STORAGE = `${appId}.clientId`;
+    const key = `${appId}.clientId`;
 
     const legacyId = getLegacyClientId();
     if (legacyId) {
         return legacyId;
     }
 
-    const clientId = storage.getItem(SK_STORAGE) ||
-    uuid.v4().replace(/-/g, '');
+    const clientId = storage.getItem(key) || uuid.v4().replace(/-/g, '');
 
-    storage.setItem(SK_STORAGE, clientId);
+    storage.setItem(key, clientId);
 
     return clientId;
 }

--- a/src/frame/js/utils/polyfills.js
+++ b/src/frame/js/utils/polyfills.js
@@ -1,13 +1,19 @@
-require('babel-polyfill');
+export function setUp() {
+    const promise = global.fetch ?
+        Promise.resolve() :
+        System.import('whatwg-fetch');
 
-if (!(Object.setPrototypeOf || {}.__proto__)) {
-    const nativeGetPrototypeOf = Object.getPrototypeOf;
+    if (!(Object.setPrototypeOf || {}.__proto__)) {
+        const nativeGetPrototypeOf = Object.getPrototypeOf;
 
-    Object.getPrototypeOf = function(object) {
-        if (object.__proto__) {
-            return object.__proto__;
-        } else {
-            return nativeGetPrototypeOf.call(Object, object);
-        }
-    };
+        Object.getPrototypeOf = function(object) {
+            if (object.__proto__) {
+                return object.__proto__;
+            } else {
+                return nativeGetPrototypeOf.call(Object, object);
+            }
+        };
+    }
+
+    return promise;
 }

--- a/src/frame/js/utils/polyfills.js
+++ b/src/frame/js/utils/polyfills.js
@@ -1,3 +1,4 @@
+require('babel-polyfill');
 export function setUp() {
     const promise = global.fetch ?
         Promise.resolve() :

--- a/src/frame/js/utils/storage.js
+++ b/src/frame/js/utils/storage.js
@@ -2,7 +2,7 @@ const memoryStorage = {};
 
 export function setItem(key, value) {
     try {
-        if (localStorage) {
+        if (global.localStorage) {
             // Safari with privacy options will have localStorage
             // but won't let us write to it.
             localStorage.setItem(key, value);
@@ -19,7 +19,7 @@ export function setItem(key, value) {
 export function getItem(key) {
     let value;
 
-    if (localStorage) {
+    if (global.localStorage) {
         value = localStorage.getItem(key) || memoryStorage[key];
     } else {
         value = memoryStorage[key];
@@ -30,6 +30,6 @@ export function getItem(key) {
 }
 
 export function removeItem(key) {
-    localStorage && localStorage.removeItem(key);
+    global.localStorage && localStorage.removeItem(key);
     delete memoryStorage[key];
 }

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,4 +1,5 @@
 'use strict';
+require('babel-polyfill');
 const {setUp} = require('../src/frame/js/utils/polyfills');
 setUp();
 const sinon = require('sinon');

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,6 +1,7 @@
 'use strict';
-require('../src/frame/js/utils/polyfills');
-var sinon = require('sinon');
+const {setUp} = require('../src/frame/js/utils/polyfills');
+setUp();
+const sinon = require('sinon');
 sinon.behavior = require('sinon/lib/sinon/behavior');
 sinon.defaultConfig = {
     injectInto: null,

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,5 +1,4 @@
 'use strict';
-require('babel-polyfill');
 const {setUp} = require('../src/frame/js/utils/polyfills');
 setUp();
 const sinon = require('sinon');


### PR DESCRIPTION
Pretty much what the title says, the `fetch` polyfill was included in `smooch-core` before and that was tested when we switched to the iframe rendering. I guess we forgot to retest it again once we brought everything in `smooch-web` and forgot to add the polyfill.

I made use of the webpack's async loading feature to only load the polyfill when needed.

Also, localStorage presence was not handled properly and apparently Safari just doesn't have a global variable for it when disabled.