### PR TITLE
4.0.1 re-release under 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "smooch",
   "description": "Smooch.io powered web messaging",
   "analyze": false,
-  "version": "4.0.0",
+  "version": "4.0.1",
   "keywords": [
     "smooch",
     "javascript",

--- a/release_notes/v4.0.2.md
+++ b/release_notes/v4.0.2.md
@@ -1,0 +1,2 @@
+# What's changed?
+- This is a re-release of the failed 4.0.1 deployment since npm won't allow reusing the same version twice.


### PR DESCRIPTION
Deployment failed for 4.0.1 and npm doesn't let you reuse the same version. This bumps it up to 4.0.2