### PR TITLE
Replace getUserId with getUser

### DIFF
--- a/release_notes/v4.0.3.md
+++ b/release_notes/v4.0.3.md
@@ -1,0 +1,2 @@
+# What's changed?
+- `getUser` is now available.

--- a/src/host/js/web-messenger.js
+++ b/src/host/js/web-messenger.js
@@ -25,7 +25,7 @@ const LIB_FUNCS = [
     'sendMessage',
     'updateUser',
     'getConversation',
-    'getUserId',
+    'getUser',
     'getCore',
     'open',
     'close',


### PR DESCRIPTION
This was forgotten when renaming getUserId to just getUser which causes the method to be unavailable once the lib is loaded.