### PR TITLE
Remove setting commits steps for sentry

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,11 +36,6 @@ module.exports = function(grunt) {
                     ].join(' && ');
                 }
             },
-            setReleaseCommits: {
-                cmd: function() {
-                    return 'npm run sentry-cli -- releases set-commits ' + grunt.config.get('globalVersion') + ' --auto';
-                }
-            },
             uploadSourceMap: {
                 cmd: function() {
                     return 'npm run sentry-cli -- releases files ' + grunt.config.get('globalVersion') + ' upload-sourcemaps ./dist/';
@@ -190,7 +185,7 @@ module.exports = function(grunt) {
     grunt.registerTask('deploy', ['build', 'exec:uploadCdn', 'exec:updateLoader']);
 
     grunt.registerTask('publish:prepare', ['versionBump', 'exec:commitFiles', 'exec:createRelease', 'build', 'exec:addDist', 'exec:addLib']);
-    grunt.registerTask('publish:release', ['release', 'exec:setReleaseCommits', 'exec:uploadSourceMap', 'exec:finalizeRelease']);
+    grunt.registerTask('publish:release', ['release', 'exec:uploadSourceMap', 'exec:finalizeRelease']);
     grunt.registerTask('publish:cleanup', ['exec:cleanRelease', 'exec:push']);
 
     grunt.registerTask('branchCheck', 'Checks that you are publishing from Master branch with no working changes', ['gitinfo', 'checkBranchStatus']);


### PR DESCRIPTION
This is most likely the culprit of our failed deployments. It was failing at detecting which commits were supposed to go in the release. Not sure why it worked when I initially tested it, but it's really not something critical for us. So to the trash it goes.