### PR TITLE
Always update appuser on message send

### DIFF
--- a/release_notes/v4.0.4.md
+++ b/release_notes/v4.0.4.md
@@ -1,0 +1,2 @@
+# What's changed?
+- Fixed a bug where the appUser would sometimes not be updated on message send

--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -240,11 +240,12 @@ function sendChain(sendFn, message) {
         };
 
         return promise
-            .then(() => {
-                return dispatch(sendFn(message))
-                    .then(postSendHandler)
-                    .catch(() => dispatch(onMessageSendFailure(message)));
-            });
+            .then(() => dispatch(immediateUpdateUser()))
+            .then(() => dispatch(sendFn(message))
+                .then(postSendHandler)
+                .catch(() => dispatch(onMessageSendFailure(message))
+            )
+        );
     };
 }
 
@@ -583,8 +584,7 @@ export function startConversation() {
         }
 
         return promise
-            .then((payload) => dispatch(handleUserConversationResponse(payload)))
-            .then(() => dispatch(immediateUpdateUser()));
+            .then((payload) => dispatch(handleUserConversationResponse(payload)));
     };
 }
 

--- a/src/frame/js/actions/integrations.js
+++ b/src/frame/js/actions/integrations.js
@@ -1,4 +1,4 @@
-import { updateUser } from './user';
+import { updateUser, immediateUpdate as immediateUpdateUser } from './user';
 import { startConversation } from './conversation';
 import { subscribe as subscribeFaye } from './faye';
 import http from './http';
@@ -124,7 +124,8 @@ function ensureUserAndFayeConnection(dispatch, getState) {
     if (getState().user._id) {
         return dispatch(subscribeFaye());
     } else {
-        return dispatch(startConversation());
+        return dispatch(startConversation())
+            .then(() => dispatch(immediateUpdateUser()));
     }
 }
 

--- a/test/specs/actions/conversation.spec.js
+++ b/test/specs/actions/conversation.spec.js
@@ -97,7 +97,7 @@ describe('Conversation Actions', () => {
         updateUserSpy = sandbox.spy(updateUser);
         ConversationActionsRewire('updateUser', updateUserSpy);
         immediateUpdateStub = sandbox.stub().returnsAsyncThunk();
-        ConversationActionsRewire('immediateUpdate', immediateUpdateStub);
+        ConversationActionsRewire('immediateUpdateUser', immediateUpdateStub);
 
         // AppState actions
         showConnectNotificationSpy = sandbox.spy(showConnectNotification);
@@ -125,6 +125,20 @@ describe('Conversation Actions', () => {
             it('should call startConversation', () => {
                 return mockedStore.dispatch(action).then(() => {
                     startConversationStub.should.have.been.calledOnce;
+                });
+            });
+        });
+    };
+
+    const updateAppUserSuite = (action, extraProps = {}) => {
+        describe('update app user', () => {
+            beforeEach(() => {
+                mockedStore = createMockedStore(sandbox, generateBaseStoreProps(extraProps));
+            });
+
+            it('should call immediateUpdate', () => {
+                return mockedStore.dispatch(action).then(() => {
+                    immediateUpdateStub.should.have.been.calledOnce;
                 });
             });
         });
@@ -226,6 +240,7 @@ describe('Conversation Actions', () => {
         });
 
         conversationStartedSuite(conversationActions.sendMessage('message'));
+        updateAppUserSuite(conversationActions.sendMessage('message'));
 
         it('should add message and send message', () => {
             mockedStore = createMockedStore(sandbox, generateBaseStoreProps());
@@ -314,6 +329,7 @@ describe('Conversation Actions', () => {
         });
 
         conversationStartedSuite(conversationActions.sendLocation(locationMessage));
+        updateAppUserSuite(conversationActions.sendLocation(locationMessage));
 
         const getCurrentLocationFailsSuite = (action) => {
             let clock;
@@ -499,6 +515,12 @@ describe('Conversation Actions', () => {
                 }
             });
 
+            updateAppUserSuite(conversationActions.resendMessage(message._clientId), {
+                conversation: {
+                    messages: [message]
+                }
+            });
+
             it('should update send status and post upload image', () => {
                 return mockedStore.dispatch(conversationActions.resendMessage(message._clientId)).then(() => {
                     postUploadImageStub.should.have.been.calledOnce;
@@ -534,6 +556,12 @@ describe('Conversation Actions', () => {
                 }
             });
 
+            updateAppUserSuite(conversationActions.resendMessage(message._clientId), {
+                conversation: {
+                    messages: [message]
+                }
+            });
+
             it('should update send status and send message', () => {
                 return mockedStore.dispatch(conversationActions.resendMessage(message._clientId)).then(() => {
                     postSendMessageStub.should.have.been.calledOnce;
@@ -559,6 +587,7 @@ describe('Conversation Actions', () => {
         });
 
         conversationStartedSuite(conversationActions.uploadImage({}));
+        updateAppUserSuite(conversationActions.uploadImage({}));
 
         describe('errors', () => {
             beforeEach(() => {

--- a/test/specs/actions/integrations.spec.js
+++ b/test/specs/actions/integrations.spec.js
@@ -17,6 +17,7 @@ describe('Integrations Actions', () => {
     let mockedStore;
     let updateUserSpy;
     let handleConversationUpdatedStub;
+    let immediateUpdateStub;
     let subscribeFayeStub;
     let updateSMSAttributesSpy;
     let setTransferRequestCodeSpy;
@@ -57,6 +58,9 @@ describe('Integrations Actions', () => {
 
         subscribeFayeStub = sandbox.stub().returnsAsyncThunk();
         IntegrationsRewire('subscribeFaye', subscribeFayeStub);
+
+        immediateUpdateStub = sandbox.stub().returnsAsyncThunk();
+        IntegrationsRewire('immediateUpdateUser', immediateUpdateStub);
 
         appUserId = hat();
         mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
@@ -168,6 +172,7 @@ describe('Integrations Actions', () => {
                 }))
                     .then(() => {
                         startConversationStub.should.have.been.calledOnce;
+                        immediateUpdateStub.should.have.been.calledOnce;
 
                         httpStub.should.have.been.calledOnce;
                         httpStub.should.have.been.calledWith('POST', `/apps/${appId}/appusers/${appUserId}/clients`, {
@@ -324,6 +329,7 @@ describe('Integrations Actions', () => {
                 return mockedStore.dispatch(integrationsActions.fetchTransferRequestCode(channel))
                     .then(() => {
                         startConversationStub.should.have.been.calledOnce;
+                        immediateUpdateStub.should.have.been.calledOnce;
                         subscribeFayeStub.should.not.have.been.calledOnce;
 
                         httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/transferrequest`, {
@@ -445,6 +451,7 @@ describe('Integrations Actions', () => {
                 return mockedStore.dispatch(integrationsActions.fetchWeChatQRCode())
                     .then(() => {
                         startConversationStub.should.have.been.calledOnce;
+                        immediateUpdateStub.should.have.been.calledOnce;
                         subscribeFayeStub.should.not.have.been.calledOnce;
 
                         httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);
@@ -563,6 +570,7 @@ describe('Integrations Actions', () => {
                 return mockedStore.dispatch(integrationsActions.fetchViberQRCode())
                     .then(() => {
                         startConversationStub.should.have.been.calledOnce;
+                        immediateUpdateStub.should.have.been.calledOnce;
                         subscribeFayeStub.should.not.have.been.calledOnce;
 
                         httpStub.should.have.been.calledWith('GET', `/apps/${appId}/appusers/${appUserId}/integrations/${integrations[0]._id}/qrcode`);


### PR DESCRIPTION
We got a report that sometimes the appUser wasn't updated before a message was sent.
This fixes that issue.