### PR TITLE
Upload props on login, return pending props with getUser()

### DIFF
--- a/release_notes/v4.0.4.md
+++ b/release_notes/v4.0.4.md
@@ -1,3 +1,4 @@
 # What's changed?
 - Fixed a bug where the appUser would sometimes not be updated on message send.
 - `getUser()` now returns any pending user properties that are waiting to be sent the to server due to the debounce mechanism around user updates.
+- Pending user properties will now be sent to the server right before a user is logged in to make sure to not lose them in the process.

--- a/release_notes/v4.0.4.md
+++ b/release_notes/v4.0.4.md
@@ -1,2 +1,3 @@
 # What's changed?
-- Fixed a bug where the appUser would sometimes not be updated on message send
+- Fixed a bug where the appUser would sometimes not be updated on message send.
+- `getUser()` now returns any pending user properties that are waiting to be sent the to server due to the debounce mechanism around user updates.

--- a/src/frame/js/actions/conversation.js
+++ b/src/frame/js/actions/conversation.js
@@ -9,6 +9,7 @@ import { disconnectClient, subscribe as subscribeFaye, unsetFayeSubscription } f
 import http from './http';
 import { setAuth } from './auth';
 import { setConfig } from './config';
+import { resetPendingUserProps } from './user';
 
 import { observable } from '../utils/events';
 import { Throttle } from '../utils/throttle';
@@ -556,8 +557,8 @@ export function handleUserConversationResponse({appUser, conversation, hasPrevio
 
 export function startConversation() {
     return (dispatch, getState) => {
-        const {user, config: {appId}, conversation: {_id: conversationId}} = getState();
-        const {_id: appUserId, userId, pendingAttributes} = user;
+        const {user, config: {appId}, conversation: {_id: conversationId}, pendingUserProps} = getState();
+        const {_id: appUserId, userId} = user;
 
         if (conversationId) {
             return Promise.resolve();
@@ -577,10 +578,11 @@ export function startConversation() {
                 });
         } else {
             promise = dispatch(http('POST', `/apps/${appId}/appusers`, {
-                ...pendingAttributes,
+                ...pendingUserProps,
                 userId,
                 client: getClientInfo(appId)
             }));
+            dispatch(resetPendingUserProps());
         }
 
         return promise

--- a/src/frame/js/actions/user.js
+++ b/src/frame/js/actions/user.js
@@ -6,8 +6,9 @@ import http from './http';
 export const SET_USER = 'SET_USER';
 export const UPDATE_USER = 'UPDATE_USER';
 export const RESET_USER = 'RESET_USER';
+export const RESET_PENDING_USER_PROPS = 'RESET_PENDING_USER_PROPS';
+export const UPDATE_PENDING_USER_PROPS = 'UPDATE_PENDING_USER_PROPS';
 
-let pendingUserProps = {};
 let pendingUpdatePromise;
 let pendingResolve;
 let pendingTimeout;
@@ -23,7 +24,7 @@ export const EDITABLE_PROPERTIES = [
 
 export function immediateUpdate(props) {
     return (dispatch, getState) => {
-        const {config: {appId, profile}, user} = getState();
+        const {config: {appId, profile}, user, pendingUserProps} = getState();
 
         const updateToResolve = pendingResolve;
         if (pendingTimeout) {
@@ -35,7 +36,7 @@ export function immediateUpdate(props) {
         lastUpdateAttempt = Date.now();
 
         props = pick(Object.assign({}, pendingUserProps, props), EDITABLE_PROPERTIES);
-        pendingUserProps = {};
+        dispatch(resetPendingUserProps());
 
         const isDirty = Object.keys(props)
             .some((key) => !deepEqual(user[key], props[key]));
@@ -69,7 +70,7 @@ export function immediateUpdate(props) {
 
 export function update(props) {
     return (dispatch, getState) => {
-        Object.assign(pendingUserProps, props);
+        dispatch(updatePendingUserProps(props));
 
         if (!getState().user._id) {
             return Promise.resolve();
@@ -82,7 +83,7 @@ export function update(props) {
         if (pendingTimeout) {
             return pendingUpdatePromise;
         } else if ((timeNow - lastUpdateTime) > waitDelay) {
-            return dispatch(immediateUpdate(pendingUserProps));
+            return dispatch(immediateUpdate());
         } else {
             const timeToWait = waitDelay - (timeNow - lastUpdateTime);
 
@@ -90,7 +91,7 @@ export function update(props) {
                 pendingResolve = resolve;
 
                 pendingTimeout = setTimeout(() => {
-                    resolve(dispatch(immediateUpdate(pendingUserProps)));
+                    resolve(dispatch(immediateUpdate()));
                 }, timeToWait);
             });
 
@@ -116,5 +117,18 @@ export function updateUser(properties) {
 export function resetUser() {
     return {
         type: RESET_USER
+    };
+}
+
+export function resetPendingUserProps() {
+    return {
+        type: RESET_PENDING_USER_PROPS
+    };
+}
+
+export function updatePendingUserProps(props = {}) {
+    return {
+        type: UPDATE_PENDING_USER_PROPS,
+        properties: pick(props, EDITABLE_PROPERTIES)
     };
 }

--- a/src/frame/js/reducers/pending-user-props.js
+++ b/src/frame/js/reducers/pending-user-props.js
@@ -1,0 +1,17 @@
+import { RESET_PENDING_USER_PROPS, UPDATE_PENDING_USER_PROPS } from '../actions/user';
+import { RESET } from '../actions/common';
+
+const INITIAL_STATE = {};
+
+export default function PendingUserReducer(state = INITIAL_STATE, action) {
+    switch (action.type) {
+        case RESET:
+            return Object.assign({}, INITIAL_STATE);
+        case UPDATE_PENDING_USER_PROPS:
+            return Object.assign({}, state, action.properties);
+        case RESET_PENDING_USER_PROPS:
+            return INITIAL_STATE;
+        default:
+            return state;
+    }
+}

--- a/src/frame/js/reducers/root.js
+++ b/src/frame/js/reducers/root.js
@@ -7,6 +7,7 @@ import UIReducer from './ui';
 import AppStateReducer from './app-state';
 import AuthReducer from './auth';
 import UserReducer from './user';
+import PendingUserPropsReducer from './pending-user-props';
 import FayeReducer from './faye';
 import BrowserReducer from './browser';
 import IntegrationsReducer from './integrations';
@@ -18,6 +19,7 @@ export default enableBatching(combineReducers({
     appState: AppStateReducer,
     auth: AuthReducer,
     user: UserReducer,
+    pendingUserProps: PendingUserPropsReducer,
     faye: FayeReducer,
     browser: BrowserReducer,
     integrations: IntegrationsReducer

--- a/src/frame/js/web-messenger.jsx
+++ b/src/frame/js/web-messenger.jsx
@@ -294,8 +294,15 @@ export function getConversation() {
 }
 
 export function getUser() {
-    const {user} = store.getState();
-    return Object.keys(user).length > 0 ? user : undefined;
+    const {user, pendingUserProps} = store.getState();
+
+    if (Object.keys(user).length === 0 && Object.keys(pendingUserProps).length === 0) {
+        return undefined;
+    }
+
+    return Object.assign({}, user, pendingUserProps, {
+        properties: Object.assign({}, user.properties, pendingUserProps.properties)
+    });
 }
 
 export function destroy() {

--- a/test/specs/actions/faye.spec.js
+++ b/test/specs/actions/faye.spec.js
@@ -325,7 +325,9 @@ describe('Faye Actions', () => {
         beforeEach(() => {
             mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
                 user: {
-                    _id: 'some-user-id'
+                    _id: 'some-user-id',
+                    pendingClients: [],
+                    clients: []
                 },
                 appState: {
                     visibleChannelType: 'messenger'

--- a/test/specs/actions/user.spec.js
+++ b/test/specs/actions/user.spec.js
@@ -10,6 +10,7 @@ describe('User Actions', () => {
     let sandbox;
     let mockedStore;
     let setUserSpy;
+    let updatePendingUserPropsSpy;
     let httpStub;
     let email;
 
@@ -22,6 +23,8 @@ describe('User Actions', () => {
 
         setUserSpy = sandbox.spy(userActions.setUser);
         UserRewire('setUser', setUserSpy);
+        updatePendingUserPropsSpy = sandbox.spy(userActions.updatePendingUserProps);
+        UserRewire('updatePendingUserProps', updatePendingUserPropsSpy);
 
         mockedStore = createMockedStore(sandbox, generateBaseStoreProps({
             config: {
@@ -33,13 +36,13 @@ describe('User Actions', () => {
             user: {
                 _id: '1',
                 email
-            }
+            },
+            pendingUserProps: {}
         }));
 
         clearTimeout(UserRewireAPI.__get__('pendingTimeout'));
         UserRewireAPI.__set__('pendingTimeout', null);
         UserRewireAPI.__set__('pendingResolve', null);
-        UserRewireAPI.__set__('pendingUserProps', {});
         UserRewireAPI.__set__('lastUpdateAttempt', undefined);
     });
 
@@ -142,7 +145,8 @@ describe('User Actions', () => {
 
             const promise = mockedStore.dispatch(userActions.update(props));
             return promise.then(() => {
-                immediateUpdateSpy.should.have.been.calledWith(props);
+                updatePendingUserPropsSpy.should.have.been.calledWith(props);
+                immediateUpdateSpy.should.have.been.called;
             });
         });
 
@@ -154,7 +158,9 @@ describe('User Actions', () => {
             const promise = mockedStore.dispatch(userActions.update(props));
             return promise
                 .then(() => {
-                    immediateUpdateSpy.should.have.been.calledWith(props);
+                    updatePendingUserPropsSpy.should.have.been.calledWith(props);
+                    immediateUpdateSpy.should.have.been.called;
+                    updatePendingUserPropsSpy.reset();
                     immediateUpdateSpy.reset();
 
                     setTimeoutStub.should.not.have.been.called;
@@ -178,7 +184,7 @@ describe('User Actions', () => {
                 })
                 .then(() => {
                     immediateUpdateSpy.should.have.been.calledOnce;
-                    immediateUpdateSpy.should.have.been.calledWith(props);
+                    updatePendingUserPropsSpy.should.have.been.calledWith(props);
                 });
         });
 
@@ -189,9 +195,10 @@ describe('User Actions', () => {
 
             return promise
                 .then(() => {
-                    immediateUpdateSpy.should.have.been.calledWith({
+                    updatePendingUserPropsSpy.should.have.been.calledWith({
                         email: 'this@email.com'
                     });
+                    immediateUpdateSpy.should.have.been.called;
                     immediateUpdateSpy.reset();
                     setTimeoutStub.should.not.have.been.called;
 
@@ -218,11 +225,15 @@ describe('User Actions', () => {
                 })
                 .then(() => {
                     immediateUpdateSpy.should.have.been.calledOnce;
-                    immediateUpdateSpy.should.have.been.calledWith({
-                        givenName: 'Example',
-                        email: 'another@email.com'
-                    });
                 });
+        });
+    });
+
+    describe('updatePendingUserProps', () => {
+        it('should only pick EDITABLE_PROPERTIES', () => {
+            const action = userActions.updatePendingUserProps({givenName: 'name', invalidProp: 'invalid'});
+            Object.keys(action.properties).should.contain('givenName');
+            Object.keys(action.properties).should.not.contain('invalidProp');
         });
     });
 });

--- a/test/specs/actions/user.spec.js
+++ b/test/specs/actions/user.spec.js
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import hat from 'hat';
 
-import { createMockedStore, generateBaseStoreProps } from '../../utils/redux';
+import { createMockedStore, generateBaseStoreProps, findActionsByType } from '../../utils/redux';
 
 import * as userActions from '../../../src/frame/js/actions/user';
 import { __Rewire__ as UserRewire, __RewireAPI__ as UserRewireAPI } from '../../../src/frame/js/actions/user';
@@ -59,6 +59,7 @@ describe('User Actions', () => {
 
                 return mockedStore.dispatch(userActions.immediateUpdate(props)).then(() => {
                     httpStub.should.not.have.been.called;
+                    findActionsByType(mockedStore.getActions(), userActions.RESET_PENDING_USER_PROPS).should.be.empty;
                 });
             });
         });
@@ -77,6 +78,8 @@ describe('User Actions', () => {
                     httpStub.should.have.been.calledWith('PUT', `/apps/${appId}/appusers/${_id}`, {
                         email: props.email
                     });
+
+                    findActionsByType(mockedStore.getActions(), userActions.RESET_PENDING_USER_PROPS).length.should.eq(1);
 
                     setUserSpy.should.have.been.calledWithMatch({
                         _id: '1',
@@ -104,6 +107,7 @@ describe('User Actions', () => {
 
                 return mockedStore.dispatch(userActions.immediateUpdate(props)).then(() => {
                     httpStub.should.not.have.been.called;
+                    findActionsByType(mockedStore.getActions(), userActions.RESET_PENDING_USER_PROPS).should.be.empty;
                 });
             });
         });

--- a/test/specs/reducers/pending-user-props.spec.js
+++ b/test/specs/reducers/pending-user-props.spec.js
@@ -1,0 +1,34 @@
+import PendingUserPropsReducer from '../../../src/frame/js/reducers/pending-user-props';
+import { UPDATE_PENDING_USER_PROPS, RESET_PENDING_USER_PROPS } from '../../../src/frame/js/actions/user';
+
+describe('PendingUserProps reducer', () => {
+    it('should be empty initialy', () => {
+        Object.keys(PendingUserPropsReducer(undefined, {})).length.should.eq(0);
+    });
+    it('should update user properties on UPDATE_PENDING_USER_PROPS', () => {
+        const state = PendingUserPropsReducer({
+            givenName: 'name'
+        }, {});
+
+        state.givenName.should.eq('name');
+
+        const newState = PendingUserPropsReducer({
+            givenName: 'name'
+        }, {
+            type: UPDATE_PENDING_USER_PROPS,
+            properties: {
+                givenName: 'other name'
+            }
+        });
+
+        newState.givenName.should.eq('other name');
+    });
+
+    it('should clear the state on RESET_PENDING_USER_PROPS', () => {
+        Object.keys(PendingUserPropsReducer({
+            some: 'prop'
+        }, {
+            type: RESET_PENDING_USER_PROPS
+        })).length.should.eq(0);
+    });
+});

--- a/test/specs/web-messenger.spec.js
+++ b/test/specs/web-messenger.spec.js
@@ -627,6 +627,90 @@ describe('WebMessenger', () => {
         });
     });
 
+    describe('Get user', () => {
+        describe('has no user initialized and has no pending user props', () => {
+            beforeEach(() => {
+                mockedStore = mockAppStore(sandbox, defaultState);
+            });
+
+            it('should return undefined', () => {
+                expect(WebMessenger.getUser()).to.be.undefined;
+            });
+        });
+
+        describe('has a user initialized and has no pending user props', () => {
+            beforeEach(() => {
+                mockedStore = mockAppStore(sandbox, {
+                    ...defaultState,
+                    user: {
+                        givenName: 'Moe',
+                        properties: {
+                            some: 'prop'
+                        }
+                    }
+                });
+            });
+
+            it('should return the user', () => {
+                const user = WebMessenger.getUser();
+                expect(user).to.exist;
+                user.givenName.should.eq('Moe');
+                user.properties.some.should.eq('prop');
+            });
+        });
+
+        describe('has no user initialized and has pending user props', () => {
+            beforeEach(() => {
+                mockedStore = mockAppStore(sandbox, {
+                    ...defaultState,
+                    pendingUserProps: {
+                        givenName: 'Bart',
+                        properties: {
+                            not: 'a prop'
+                        }
+                    }
+                });
+            });
+
+            it('should return the pending props', () => {
+                const user = WebMessenger.getUser();
+                expect(user).to.exist;
+                user.givenName.should.eq('Bart');
+                user.properties.not.should.eq('a prop');
+            });
+        });
+
+        describe('has a user initialized and has pending user props', () => {
+            beforeEach(() => {
+                mockedStore = mockAppStore(sandbox, {
+                    ...defaultState,
+                    user: {
+                        givenName: 'Moe',
+                        email: 'moe@tavern.drink',
+                        properties: {
+                            some: 'prop'
+                        }
+                    },
+                    pendingUserProps: {
+                        givenName: 'Bart',
+                        properties: {
+                            not: 'a prop'
+                        }
+                    }
+                });
+            });
+
+            it('should return the merged user and pending props', () => {
+                const user = WebMessenger.getUser();
+                expect(user).to.exist;
+                user.givenName.should.eq('Bart');
+                user.email.should.eq('moe@tavern.drink');
+                user.properties.some.should.eq('prop');
+                user.properties.not.should.eq('a prop');
+            });
+        });
+    });
+
     describe('Update user', () => {
         beforeEach(() => {
             updateUserStub.returnsAsyncThunk({

--- a/test/utils/redux.js
+++ b/test/utils/redux.js
@@ -19,9 +19,10 @@ export function generateBaseStoreProps(extraProps = {}) {
             ...extraProps.integrations
         },
         user: {
-            pendingClients: [],
-            clients: [],
             ...extraProps.user
+        },
+        pendingUserProps: {
+            ...extraProps.pendingUserProps
         },
         appState: {
             isInitialized: true,


### PR DESCRIPTION
This PR fixes two things : 
- Pending props were not handled properly when a user was logged in and there were pending props to be uploaded
- `getUser()` was not returning the pending props if there was any and it gave the impression the props were lost in the void.

I ended up creating a new reducer to hold pending props. There was a `pendingAttributes` key in the user props, but I search for the place where it's actually updated, and turns out, it didn't happen. Pending props were previously stored in a variable inside the User action scope which was kind of bad.